### PR TITLE
Fix broken Markdown

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -7,88 +7,88 @@ This list contains fifty nine rules, in six categories.
 
 The following rules signal possible mistakes in the code.
 
- * [no-dangling-reference] (no-dangling-reference.md) - 
+ * [no-dangling-reference](no-dangling-reference.md) - 
 
 ## Good Practices
 
 The following rules are common sense practices that help avoid bugs or conflicts.
 
- * [always-have-visibility] (always-have-visibility.md) - 
- * [commented-fallthrough] (commented-fallthrough.md) - 
- * [compatible-typehint] (compatible-typehint.md) - 
- * [constant-condition] (constant-condition.md) - 
- * [declares-or-executes] (declares-or-executes.md) - 
- * [definitions-only] (definitions-only.md) - 
- * [lowercase-keyword] (lowercase-keyword.md) - 
- * [no-assign-null-method] (no-assign-null-method.md) - 
- * [no-catch-overwrite] (no-catch-overwrite.md) - 
- * [no-commented-code] (no-commented-code.md) - 
- * [no-curly-array] (no-curly-array.md) - 
- * [no-dangling-commas] (no-dangling-commas.md) - 
- * [no-dead-code] (no-dead-code.md) - 
- * [no-double-quote] (no-double-quote.md) - 
- * [no-duplicate-case] (no-duplicate-case.md) - 
- * [no-duplicate-key] (no-duplicate-key.md) - 
- * [no-duplicated-code] (no-duplicated-code.md) - 
- * [no-empty-catch] (no-empty-catch.md) - 
- * [no-exit] (no-exit.md) - 
- * [no-extra-argument] (no-extra-argument.md) - 
- * [no-global] (no-global.md) - 
- * [no-goto] (no-goto.md) - 
- * [no-hardcoded-path] (no-hardcoded-path.md) - 
- * [no-incompilable] (no-incompilable.md) - 
- * [no-isolated-block] (no-isolated-block.md) - 
- * [no-missing-argument] (no-missing-argument.md) - 
- * [no-multiple-instruction-per-line] (no-multiple-instruction-per-line.md) - 
- * [no-nested-ternary] (no-nested-ternary.md) - 
- * [no-noscream] (no-noscream.md) - 
- * [no-reserved-keywords] (no-reserved-keywords.md) - 
- * [no-return-void] (no-return-void.md) - 
- * [no-static-this] (no-static-this.md) - 
- * [no-switch-without-default] (no-switch-without-default.md) - 
- * [no-undefined-variables] (no-undefined-variables.md) - 
- * [no-useless-instruction] (no-useless-instruction.md) - 
- * [one-class-per-file] (one-class-per-file.md) - 
- * [one-instruction-per-line] (one-instruction-per-line.md) - 
- * [strict-comparisons] (strict-comparisons.md) - 
- * [unused-arguments] (unused-arguments.md) - 
- * [unused-variable] (unused-variable.md) - 
- * [use-const] (use-const.md) - 
- * [use-self] (use-self.md) - 
+ * [always-have-visibility](always-have-visibility.md) - 
+ * [commented-fallthrough](commented-fallthrough.md) - 
+ * [compatible-typehint](compatible-typehint.md) - 
+ * [constant-condition](constant-condition.md) - 
+ * [declares-or-executes](declares-or-executes.md) - 
+ * [definitions-only](definitions-only.md) - 
+ * [lowercase-keyword](lowercase-keyword.md) - 
+ * [no-assign-null-method](no-assign-null-method.md) - 
+ * [no-catch-overwrite](no-catch-overwrite.md) - 
+ * [no-commented-code](no-commented-code.md) - 
+ * [no-curly-array](no-curly-array.md) - 
+ * [no-dangling-commas](no-dangling-commas.md) - 
+ * [no-dead-code](no-dead-code.md) - 
+ * [no-double-quote](no-double-quote.md) - 
+ * [no-duplicate-case](no-duplicate-case.md) - 
+ * [no-duplicate-key](no-duplicate-key.md) - 
+ * [no-duplicated-code](no-duplicated-code.md) - 
+ * [no-empty-catch](no-empty-catch.md) - 
+ * [no-exit](no-exit.md) - 
+ * [no-extra-argument](no-extra-argument.md) - 
+ * [no-global](no-global.md) - 
+ * [no-goto](no-goto.md) - 
+ * [no-hardcoded-path](no-hardcoded-path.md) - 
+ * [no-incompilable](no-incompilable.md) - 
+ * [no-isolated-block](no-isolated-block.md) - 
+ * [no-missing-argument](no-missing-argument.md) - 
+ * [no-multiple-instruction-per-line](no-multiple-instruction-per-line.md) - 
+ * [no-nested-ternary](no-nested-ternary.md) - 
+ * [no-noscream](no-noscream.md) - 
+ * [no-reserved-keywords](no-reserved-keywords.md) - 
+ * [no-return-void](no-return-void.md) - 
+ * [no-static-this](no-static-this.md) - 
+ * [no-switch-without-default](no-switch-without-default.md) - 
+ * [no-undefined-variables](no-undefined-variables.md) - 
+ * [no-useless-instruction](no-useless-instruction.md) - 
+ * [one-class-per-file](one-class-per-file.md) - 
+ * [one-instruction-per-line](one-instruction-per-line.md) - 
+ * [strict-comparisons](strict-comparisons.md) - 
+ * [unused-arguments](unused-arguments.md) - 
+ * [unused-variable](unused-variable.md) - 
+ * [use-const](use-const.md) - 
+ * [use-self](use-self.md) - 
 
 ## Security
 
 The following rules are help strengthening the security of your application.
 
- * [no-debug] (no-debug.md) - 
- * [no-eval] (no-eval.md) - 
- * [no-hardcoded-credential] (no-hardcoded-credential.md) - 
- * [no-sleep] (no-sleep.md) - 
+ * [no-debug](no-debug.md) - 
+ * [no-eval](no-eval.md) - 
+ * [no-hardcoded-credential](no-hardcoded-credential.md) - 
+ * [no-sleep](no-sleep.md) - 
 
 ## PHP Manual recommendations
 
 The following rules are extracted from the manual.
 
- * [no-aliases] (no-aliases.md) - 
- * [no-deprecated] (no-deprecated.md) - 
- * [no-letter-logical] (no-letter-logical.md) - 
- * [no-return-with-parenthesis] (no-return-with-parenthesis.md) - 
- * [no-short-tags] (no-short-tags.md) - 
+ * [no-aliases](no-aliases.md) - 
+ * [no-deprecated](no-deprecated.md) - 
+ * [no-letter-logical](no-letter-logical.md) - 
+ * [no-return-with-parenthesis](no-return-with-parenthesis.md) - 
+ * [no-short-tags](no-short-tags.md) - 
 
 ## Coding Conventions
 
 The following rules are common coding conventions. They don't change PHP code, but will impact coding and understanding.
 
- * [no-bracketless-blocks] (no-bracketless-blocks.md) - 
- * [no-php4-constructor] (no-php4-constructor.md) - 
+ * [no-bracketless-blocks](no-bracketless-blocks.md) - 
+ * [no-php4-constructor](no-php4-constructor.md) - 
 
 ## Performances
 
 The following rules will speed up the code execution.
 
- * [always-preprocess] (always-preprocess.md) - 
- * [no-array-unique] (no-array-unique.md) - 
- * [no-functioncal-in-loop] (no-functioncal-in-loop.md) - 
- * [no-recalculate] (no-recalculate.md) - 
- * [no-repeated-print] (no-repeated-print.md) - 
+ * [always-preprocess](always-preprocess.md) - 
+ * [no-array-unique](no-array-unique.md) - 
+ * [no-functioncal-in-loop](no-functioncal-in-loop.md) - 
+ * [no-recalculate](no-recalculate.md) - 
+ * [no-repeated-print](no-repeated-print.md) - 
 

--- a/rules/constant-condition.md
+++ b/rules/constant-condition.md
@@ -87,5 +87,5 @@ for ( ; $object->property == 2 ; ) {
 
 ## Further Reading 
 
-* [PHP functions aliases] (http://php.net/manual/en/aliases.php)
+* [PHP functions aliases](http://php.net/manual/en/aliases.php)
 -->

--- a/rules/no-aliases.md
+++ b/rules/no-aliases.md
@@ -45,4 +45,4 @@ if (is_int($value)) {
 
 ## Further Reading 
 
-* [PHP functions aliases] (http://php.net/manual/en/aliases.php)
+* [PHP functions aliases](http://php.net/manual/en/aliases.php)

--- a/rules/no-extra-argument.md
+++ b/rules/no-extra-argument.md
@@ -64,6 +64,6 @@ z(1, 2, 3, 4);
 
 ## Further Reading 
 * [func_get_arg](http://php.net/manual/en/function.func-get-arg.php)
-* [func_get_args] (http://php.net/manual/en/aliases.php)
+* [func_get_args](http://php.net/manual/en/aliases.php)
 * [func_num_args](http://php.net/manual/en/function.func-num-args.php)
 * [Variable-length argument lists](http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list)

--- a/rules/no-return-with-parenthesis.md
+++ b/rules/no-return-with-parenthesis.md
@@ -53,4 +53,4 @@ function x() {
 
 ## Further Reading 
 
-* [Return] (http://php.net/manual/en/function.return.php)
+* [Return](http://php.net/manual/en/function.return.php)

--- a/rules/no-undefined-variables.md
+++ b/rules/no-undefined-variables.md
@@ -54,5 +54,5 @@ functionCall($undefinedVariable);
 
 ## Further Reading 
 
-* [PHP functions aliases] (http://php.net/manual/en/aliases.php)
+* [PHP functions aliases](http://php.net/manual/en/aliases.php)
 -->


### PR DESCRIPTION
Github recently [migrated to a new Markdown parser](https://githubengineering.com/a-formal-spec-for-github-markdown/).

The new parser supports a slightly different flavour of Markdown. In particular, it does not like a space in links like this: `[foo] (http://example.com)`